### PR TITLE
Bugfix Fotogröße

### DIFF
--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/ViewImageActivity.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/ViewImageActivity.java
@@ -3,12 +3,10 @@ package de.bahnhoefe.deutschlands.bahnhofsfotos;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
-import android.media.Image;
-import android.support.annotation.Nullable;
+import android.os.Bundle;
 import android.support.v4.app.NavUtils;
 import android.support.v4.app.TaskStackBuilder;
 import android.support.v7.app.AppCompatActivity;
-import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
 import android.widget.ImageView;
@@ -17,6 +15,7 @@ import android.widget.TextView;
 public class ViewImageActivity extends AppCompatActivity {
 
 
+    private static final String TAG = ViewImageActivity.class.getSimpleName();
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -44,28 +43,19 @@ public class ViewImageActivity extends AppCompatActivity {
         // Locate the TextView in view_image.xml
         text = (TextView) findViewById(R.id.imagetext);
 
+        // Locate the ImageView in view_image.xml
+        imageview = (ImageView) findViewById(R.id.full_image_view);
+        if (imageview == null)
+            throw new IllegalStateException("Could not find full_image_view");
+
         // Load the text into the TextView followed by the position
         text.setText(filename[position]);
 
-        Bitmap myBitmap = BitmapFactory.decodeFile(filepath[position]);
+        Bitmap scaled = BitmapFactory.decodeFile(filepath[position]);
 
-        int width = 300;
-        int height = 300;
-        Log.e("Screen width ", " " + width);
-        Log.e("Screen height ", " " + height);
-        Log.e("img width ", " " + myBitmap.getWidth());
-        Log.e("img height ", " " + myBitmap.getHeight());
+        Log.e(TAG, "img width " + scaled.getWidth());
 
-        float scaleHt = (float) width / myBitmap.getWidth();
-        Log.e("Scaled percent ", " " + scaleHt);
-        Bitmap scaled = Bitmap.createScaledBitmap(myBitmap, width, (int) (myBitmap.getHeight() * scaleHt), true);
-
-
-
-        // Locate the ImageView in view_image.xml
-        imageview = (ImageView) findViewById(R.id.full_image_view);
         imageview.setImageBitmap(scaled);
-
     }
 
     @Override

--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/notification/NearbyBahnhofWithPhotoNotificationManager.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/notification/NearbyBahnhofWithPhotoNotificationManager.java
@@ -34,8 +34,7 @@ public class NearbyBahnhofWithPhotoNotificationManager extends NearbyBahnhofNoti
     @Override
     public void notifyUser() {
         BitmapFactory.Options options = new BitmapFactory.Options();
-        options.outWidth = 640;
-        fetchTask = new BahnhofsFotoFetchTask(this, options);
+        fetchTask = new BahnhofsFotoFetchTask(this);
         fetchTask.execute(notificationStation.getId());
     }
 

--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BahnhofsFotoFetchTask.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BahnhofsFotoFetchTask.java
@@ -1,6 +1,5 @@
 package de.bahnhoefe.deutschlands.bahnhofsfotos.util;
 
-import android.graphics.BitmapFactory;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.util.Log;
@@ -24,14 +23,12 @@ public class BahnhofsFotoFetchTask extends AsyncTask<Integer, Void, URL> {
     private final static String TAG = BahnhofsFotoFetchTask.class.getSimpleName();
     private final BitmapAvailableHandler handler;
     private final static String descriptorUrlPattern = "http://www.deutschlands-bahnhoefe.org/bahnhofsfotos/%d/bahnhofsnr.json";
-    private BitmapFactory.Options options;
     private String license;
     private Uri authorReference;
     private String author;
 
-    public BahnhofsFotoFetchTask(BitmapAvailableHandler handler, BitmapFactory.Options bitmapOptionsForScreen) {
+    public BahnhofsFotoFetchTask(BitmapAvailableHandler handler) {
         this.handler = handler;
-        this.options = bitmapOptionsForScreen;
     }
 
     @Override
@@ -46,7 +43,7 @@ public class BahnhofsFotoFetchTask extends AsyncTask<Integer, Void, URL> {
         if (url != null) {
             Log.i(TAG, "Fetching photo from " + url);
             // fetch bitmap asynchronously, call onBitmapAvailable if ready
-            BitmapCache.getInstance().getFoto(handler, url, options);
+            BitmapCache.getInstance().getFoto(handler, url);
         } else {
             handler.onBitmapAvailable(null);
         }

--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BitmapCache.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BitmapCache.java
@@ -5,7 +5,6 @@ package de.bahnhoefe.deutschlands.bahnhofsfotos.util;
  */
 
 import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -83,20 +82,17 @@ public class BitmapCache  {
 
 
     /**
-     * Get a picture for the given URL, either from cache or by downloading. Apply the given options.
+     * Get a picture for the given URL, either from cache or by downloading.
      * The fetching happens asynchronously. When finished, the provided callback interface is called.
-     * @todo the implementation silently assumes that any URL will always be requested with the same options...
      * @param callback the BitmapAvailableHandler to call on completion.
      * @param resourceUrl the URL to fetch
-     * @param options the Options to apply
      */
-    public void getFoto (BitmapAvailableHandler callback, @NonNull URL resourceUrl, @Nullable BitmapFactory.Options options) {
+    public void getFoto(BitmapAvailableHandler callback, @NonNull URL resourceUrl) {
         Bitmap bitmap = cache.get (resourceUrl);
         if (bitmap == null) {
             BitmapDownloader downloader = new BitmapDownloader(
                     new Request(resourceUrl, callback),
-                    resourceUrl,
-                    options);
+                    resourceUrl);
             synchronized (requests) {
                 Collection<BitmapAvailableHandler> handlers = requests.get (resourceUrl);
                 if (handlers == null) {

--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BitmapDownloader.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/BitmapDownloader.java
@@ -3,7 +3,6 @@ package de.bahnhoefe.deutschlands.bahnhofsfotos.util;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
-import android.support.annotation.Nullable;
 import android.util.Log;
 
 import java.io.IOException;
@@ -26,9 +25,8 @@ public class BitmapDownloader extends AsyncTask<Void, Void, Bitmap> {
      * Construct a bitmap Downloader for the given URL
      * @param handler the BitmapAvailableHandler instance that is called on completion
      * @param url the URL to fetch the Bitmap from
-     * @param options the Options to pass to BitmapFactory. May be null.
      */
-    public BitmapDownloader(BitmapAvailableHandler handler, URL url, @Nullable BitmapFactory.Options options) {
+    public BitmapDownloader(BitmapAvailableHandler handler, URL url) {
         this.bitmapAvailableHandler = handler;
         this.url = url;
         this.options = options;

--- a/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/GridViewAdapter.java
+++ b/app/src/main/java/de/bahnhoefe/deutschlands/bahnhofsfotos/util/GridViewAdapter.java
@@ -12,6 +12,7 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import de.bahnhoefe.deutschlands.bahnhofsfotos.DetailsActivity;
 import de.bahnhoefe.deutschlands.bahnhofsfotos.R;
 
 //import static com.google.android.gms.analytics.internal.zzy.G;
@@ -67,7 +68,7 @@ public class GridViewAdapter extends BaseAdapter {
         text.setText(filename[position]);
 
         BitmapFactory.Options options = new BitmapFactory.Options();
-        options.outWidth = 100;
+        options.inSampleSize = DetailsActivity.STORED_FOTO_WIDTH / 100;
         Bitmap scaled = BitmapFactory.decodeFile(filepath[position], options);
 
         if (scaled != null) {


### PR DESCRIPTION
- consequent misinterpretation of BitmapFactory.Options corrected
- fotos are now stored in a more sensible size
- fotos are now resampled instead of scaled, should work a lot faster and give reasonable results